### PR TITLE
Added a Corner Pin shader

### DIFF
--- a/data/examples/corner_pin.shader
+++ b/data/examples/corner_pin.shader
@@ -19,17 +19,17 @@ float cross2d(float2 a, float2 b)
 
 float2 invBilinear(float2 p)
 {
-	float2 a = float2(_TLx / 1000.0, _TLy / 1000.0);
-	float2 b = float2(1.0 - (_TRx / 1000.0), _TRy / 1000.0);
-	float2 c = float2(1.0 - (_DRx / 1000.0), 1.0 - (_DRy / 1000.0));
-	float2 d = float2(_DLx / 1000.0, 1.0 - (_DLy / 1000.0));
+    float2 a = float2(_TLx / 1000.0, _TLy / 1000.0);
+    float2 b = float2(1.0 - (_TRx / 1000.0), _TRy / 1000.0);
+    float2 c = float2(1.0 - (_DRx / 1000.0), 1.0 - (_DRy / 1000.0));
+    float2 d = float2(_DLx / 1000.0, 1.0 - (_DLy / 1000.0));
 	
     float2 e = b-a;
     float2 f = d-a;
     float2 g = a-b+c-d;
     float2 h = p-a;
 	
-	float k2 = cross2d( g, f );
+    float k2 = cross2d( g, f );
     float k1 = cross2d( e, f ) + cross2d( h, g );
     float k0 = cross2d( h, e );
     
@@ -74,6 +74,6 @@ float2 invBilinear(float2 p)
 }
 
 float4 mainImage(VertData v_in) : TARGET
-{	
-	return image.Sample(textureSampler, invBilinear(v_in.uv));
+{
+    return image.Sample(textureSampler, invBilinear(v_in.uv));
 }

--- a/data/examples/corner_pin.shader
+++ b/data/examples/corner_pin.shader
@@ -67,10 +67,10 @@ float2 invBilinear(float2 p)
     
     float2 res = float2(-1.0, -1.0);
 
-    if(  b1 && !b2 ) res = float2( u1, v1 );
-    if( !b1 &&  b2 ) res = float2( u2, v2 );
-    
-    return res;
+    if( b2 ) return float2( u2, v2 );
+    if( b1 ) return float2( u1, v1 );
+	
+    return float2(-1.0, -1.0);
 }
 
 float4 mainImage(VertData v_in) : TARGET

--- a/data/examples/corner_pin.shader
+++ b/data/examples/corner_pin.shader
@@ -12,7 +12,7 @@ uniform float _TLy;
 uniform float _TRx;
 uniform float _TRy;
 
-float cross(float2 a, float2 b)
+float cross2d(float2 a, float2 b)
 {
 	return (a.x * b.y) - (a.y * b.x);
 }
@@ -29,37 +29,48 @@ float2 invBilinear(float2 p)
     float2 g = a-b+c-d;
     float2 h = p-a;
 	
-	float k2 = cross( g, f );
-    float k1 = cross( e, f ) + cross( h, g );
-    float k0 = cross( h, e );
-	
-	// if edges are parallel, use linear equation
-	if( abs(k2)<0.001 )
+	float k2 = cross2d( g, f );
+    float k1 = cross2d( e, f ) + cross2d( h, g );
+    float k0 = cross2d( h, e );
+    
+    float k2u = cross2d( e, g );
+    float k1u = cross2d( e, f ) + cross2d( g, h );
+    float k0u = cross2d( h, f);    
+   
+    float v1, u1, v2, u2;
+    
+    if (abs(k2) < 0.0001) 
     {
-        float v = -k0/k1;
-        float u  = (h.x*k1+f.x*k0) / (e.x*k1-g.x*k0);
-        if( v>0.0 && v<1.0 && u>0.0 && u<1.0 ) {
-			return float2( u, v );
-		}
+        v1 = -k0 / k1;
+        u1 = (h.x - f.x*v1)/(e.x + g.x*v1);
+    } 
+    else if (abs(k2u) < 0.0001) 
+    {
+        u1 = k0u / k1u;
+        v1 = (h.y - e.y*u1)/(f.y + g.y*u1);
+    } 
+    else 
+    {
+        float w = k1*k1 - 4.0*k0*k2;
+
+        if( w<0.0 ) return float2(-1.0, -1.0);
+
+        w = sqrt( w );
+
+        v1 = (-k1 - w)/(2.0*k2);
+        v2 = (-k1 + w)/(2.0*k2);
+        u1 = (-k1u - w)/(2.0*k2u);
+        u2 = (-k1u + w)/(2.0*k2u);
     }
+    bool  b1 = v1>0.0 && v1<1.0 && u1>0.0 && u1<1.0;
+    bool  b2 = v2>0.0 && v2<1.0 && u2>0.0 && u2<1.0;
+    
+    float2 res = float2(-1.0, -1.0);
 
-	// otherwise, it's a quadratic
-	float w = k1*k1 - 4.0*k0*k2;
-	
-	if( w < 0.0 ) {
-		return float2(-1.0, -1.0);
-	}
-	
-	w = sqrt( w );
-
-	float ik2 = 0.5/k2;
-	float v = (-k1 - w)*ik2; if( v<0.0 || v>1.0 ) v = (-k1 + w)*ik2;
-	float u = (h.x - f.x*v)/(e.x + g.x*v);
-	
-	if( u<0.0 || u>1.0 || v<0.0 || v>1.0 ) {
-		return float2(-1.0, -1.0);
-	}
-	return float2( u, v );
+    if(  b1 && !b2 ) res = float2( u1, v1 );
+    if( !b1 &&  b2 ) res = float2( u2, v2 );
+    
+    return res;
 }
 
 float4 mainImage(VertData v_in) : TARGET

--- a/data/examples/corner_pin.shader
+++ b/data/examples/corner_pin.shader
@@ -1,0 +1,68 @@
+// Corner Pin shader by rmanky
+// --- --- ---
+// Adapted from https://www.iquilezles.org/www/articles/ibilinear/ibilinear.htm
+// and this Shadertoy example https://www.shadertoy.com/view/lsBSDm
+
+uniform float _DRx;
+uniform float _DRy;
+uniform float _DLx;
+uniform float _DLy;
+uniform float _TLx;
+uniform float _TLy;
+uniform float _TRx;
+uniform float _TRy;
+
+float cross(float2 a, float2 b)
+{
+	return (a.x * b.y) - (a.y * b.x);
+}
+
+float2 invBilinear(float2 p)
+{
+	float2 a = float2(_TLx / 1000.0, _TLy / 1000.0);
+	float2 b = float2(1.0 - (_TRx / 1000.0), _TRy / 1000.0);
+	float2 c = float2(1.0 - (_DRx / 1000.0), 1.0 - (_DRy / 1000.0));
+	float2 d = float2(_DLx / 1000.0, 1.0 - (_DLy / 1000.0));
+	
+    float2 e = b-a;
+    float2 f = d-a;
+    float2 g = a-b+c-d;
+    float2 h = p-a;
+	
+	float k2 = cross( g, f );
+    float k1 = cross( e, f ) + cross( h, g );
+    float k0 = cross( h, e );
+	
+	// if edges are parallel, use linear equation
+	if( abs(k2)<0.001 )
+    {
+        float v = -k0/k1;
+        float u  = (h.x*k1+f.x*k0) / (e.x*k1-g.x*k0);
+        if( v>0.0 && v<1.0 && u>0.0 && u<1.0 ) {
+			return float2( u, v );
+		}
+    }
+
+	// otherwise, it's a quadratic
+	float w = k1*k1 - 4.0*k0*k2;
+	
+	if( w < 0.0 ) {
+		return float2(-1.0, -1.0);
+	}
+	
+	w = sqrt( w );
+
+	float ik2 = 0.5/k2;
+	float v = (-k1 - w)*ik2; if( v<0.0 || v>1.0 ) v = (-k1 + w)*ik2;
+	float u = (h.x - f.x*v)/(e.x + g.x*v);
+	
+	if( u<0.0 || u>1.0 || v<0.0 || v>1.0 ) {
+		return float2(-1.0, -1.0);
+	}
+	return float2( u, v );
+}
+
+float4 mainImage(VertData v_in) : TARGET
+{	
+	return image.Sample(textureSampler, invBilinear(v_in.uv));
+}


### PR DESCRIPTION
Using https://www.iquilezles.org/www/articles/ibilinear/ibilinear.htm and https://www.shadertoy.com/view/lsBSDm, I adapted a corner pin shader for OBS.

It has been requested elsewhere on the internet (like [here](https://ideas.obsproject.com/posts/577/corner-pin-effect) and [here](https://github.com/Xaymar/obs-StreamFX/issues/281)), so I thought I'd have a go at it.

It is useful for doing things like this (the chat on the right is a browser source, which gains perspective via the corner pin):
![obs64_0N74RhU42N](https://user-images.githubusercontent.com/16567259/99418487-12919380-28c9-11eb-850c-5be2c5396fc6.png)

This implementation avoids the issue of linear interpolation, as discussed in this great [article](http://reedbeta.com/blog/quadrilateral-interpolation-part-1/) by Nathan Reed.

This is my first pull request to a public/large project, so let me know if there is anything I can improve!

**Edit 11/20/2020:**
Used a suggestion from the shadertoy page to allow for even wackier configurations, like in situations were the pins cause a twist in the middle:
![edit](https://i.imgur.com/JqoabYh.jpg)