### PR TITLE
fix crash param_rand_instance_f not reset

### DIFF
--- a/src/obs-shaderfilter.c
+++ b/src/obs-shaderfilter.c
@@ -195,6 +195,7 @@ static void shader_filter_reload_effect(struct shader_filter_data *filter)
 	filter->param_uv_size = NULL;
 	filter->param_rand_f = NULL;	
 	filter->param_rand_activation_f = NULL;
+	filter->param_rand_instance_f = NULL;
 	filter->param_loops = NULL;
 	filter->param_local_time = NULL;
 


### PR DESCRIPTION
when going from an effect that has the rand_instance_f parameter to an effect that does not have the parameter (shake.effect) OBS would crash